### PR TITLE
Handle parameters on nested fields

### DIFF
--- a/src/Fields.ts
+++ b/src/Fields.ts
@@ -1,8 +1,10 @@
+import NestedField from "./NestedField";
+
 /*
 Defines an array of strings or objects to define query fields
 @example ['id', 'name']
 @example [{id: 1, name: 'Chuck'}]
  */
-type Fields = Array<string | object>;
+type Fields = Array<string | object | NestedField>;
 
 export default Fields;

--- a/src/NestedField.ts
+++ b/src/NestedField.ts
@@ -1,0 +1,24 @@
+import IQueryBuilderOptions from "./IQueryBuilderOptions";
+import Fields from "./Fields";
+
+/*
+Defines an array of strings or objects to define query fields
+@example ['id', 'name']
+@example [{id: 1, name: 'Chuck'}]
+ */
+type NestedField = {
+  operation: String;
+  variables: IQueryBuilderOptions[];
+  fields: Fields;
+};
+
+export default NestedField;
+
+export function isNestedField(object: any): object is NestedField {
+  return (
+    typeof object === "object" &&
+    object.hasOwnProperty("operation") &&
+    object.hasOwnProperty("variables") &&
+    object.hasOwnProperty("fields")
+  );
+}

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -1,5 +1,6 @@
 import Fields from "./Fields";
 import IQueryBuilderOptions from "./IQueryBuilderOptions";
+import NestedField, { isNestedField } from "./NestedField";
 
 export default class Utils {
   public static resolveVariables(operations: IQueryBuilderOptions[]): any {
@@ -12,8 +13,9 @@ export default class Utils {
     return ret;
   }
 
-  public static createVariableString(variables: IQueryBuilderOptions[]) {
-    return Object.keys(variables).length
+  // Convert object to name and argument map. eg: (id: $id)
+  public static queryDataNameAndArgumentMap(variables: IQueryBuilderOptions[]) {
+    return variables && Object.keys(variables).length
       ? `(${Object.keys(variables).reduce(
           (dataString, key, i) =>
             `${dataString}${i !== 0 ? ", " : ""}${key}: $${key}`,
@@ -25,27 +27,29 @@ export default class Utils {
   public static queryFieldsMap(fields?: Fields): string {
     return fields
       ? fields
-          .map((field) =>
-            typeof field === "object"
-              ? field.hasOwnProperty("operation")
-                ? `${
-                    (field as { operation: String }).operation
-                  } ${this.createVariableString(
-                    (field as { variables: IQueryBuilderOptions[] }).variables
-                  )} { ${this.queryFieldsMap(
-                    (field as { fields: Fields }).fields
-                  )} }`
-                : `${Object.keys(field)[0]} { ${this.queryFieldsMap(
-                    Object.values(field)[0]
-                  )} }`
-              : `${field}`
-          )
+          .map((field) => {
+            if (isNestedField(field)) {
+              return Utils.queryNestedFieldMap(field);
+            } else if (typeof field === "object") {
+              return `${Object.keys(field)[0]} { ${this.queryFieldsMap(
+                Object.values(field)[0] as Fields
+              )} }`;
+            } else {
+              return `${field}`;
+            }
+          })
           .join(", ")
       : "";
   }
 
+  public static queryNestedFieldMap(field: NestedField) {
+    return `${field.operation} ${this.queryDataNameAndArgumentMap(
+      field.variables
+    )} { ${this.queryFieldsMap(field.fields)} }`;
+  }
+
   // Variables map. eg: { "id": 1, "name": "Jon Doe" }
-  public static queryVariablesMap(variables: any, fields?: any) {
+  public static queryVariablesMap(variables: any, fields?: Fields) {
     let variablesMapped: { [key: string]: unknown } = {};
     if (variables) {
       Object.keys(variables).map((key) => {
@@ -55,15 +59,28 @@ export default class Utils {
             : variables[key];
       });
     }
-    fields?.forEach((field: any) => {
-      if ((field as { variables: IQueryBuilderOptions[] }).variables) {
-        variablesMapped = {
-          ...(field as { variables: IQueryBuilderOptions[] }).variables,
-          ...variablesMapped,
+
+    if (fields && typeof fields === "object") {
+      variablesMapped = {
+        ...Utils.getNestedVariables(fields),
+        ...variablesMapped,
+      };
+    }
+    return variablesMapped;
+  }
+
+  public static getNestedVariables(fields: Fields) {
+    let variables = {};
+    fields?.forEach((field: string | object | NestedField) => {
+      if (isNestedField(field)) {
+        variables = {
+          ...field.variables,
+          ...variables,
+          ...(field.fields && Utils.getNestedVariables(field.fields)),
         };
       }
     });
-    return variablesMapped;
+    return variables;
   }
 
   public static queryDataType(variable: any) {

--- a/src/adapters/DefaultQueryAdapter.ts
+++ b/src/adapters/DefaultQueryAdapter.ts
@@ -44,28 +44,16 @@ export default class DefaultQueryAdapter implements IQueryAdapter {
     return this.operationWrapperTemplate(content());
   }
 
-  // Convert object to name and argument map. eg: (id: $id)
-  public queryDataNameAndArgumentMap() {
-    return this.variables && Object.keys(this.variables).length
-      ? `(${Object.keys(this.variables).reduce(
-          (dataString, key, i) =>
-            `${dataString}${i !== 0 ? ", " : ""}${key}: $${key}`,
-          ""
-        )})`
-      : "";
-  }
-
   // Convert object to argument and type map. eg: ($id: Int)
   private queryDataArgumentAndTypeMap(): string {
     let variablesUsed: { [key: string]: unknown } = this.variables;
-    this.fields?.forEach((field: any) => {
-      if ((field as { variables: IQueryBuilderOptions[] }).variables) {
-        variablesUsed = {
-          ...(field as { variables: IQueryBuilderOptions[] }).variables,
-          ...variablesUsed,
-        };
-      }
-    });
+
+    if (this.fields && typeof this.fields === "object") {
+      variablesUsed = {
+        ...Utils.getNestedVariables(this.fields),
+        ...variablesUsed,
+      };
+    }
     return variablesUsed && Object.keys(variablesUsed).length
       ? `(${Object.keys(variablesUsed).reduce(
           (dataString, key, i) =>
@@ -89,10 +77,8 @@ export default class DefaultQueryAdapter implements IQueryAdapter {
   }
   // query
   private operationTemplate() {
-    return `${
-      this.operation
-    } ${this.queryDataNameAndArgumentMap()} { ${Utils.queryFieldsMap(
-      this.fields
-    )} }`;
+    return `${this.operation} ${Utils.queryDataNameAndArgumentMap(
+      this.variables
+    )} { ${Utils.queryFieldsMap(this.fields)} }`;
   }
 }

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -143,6 +143,26 @@ describe("Query", () => {
       variables: {},
     });
   });
+
+  test("generates query with variables nested in fields", () => {
+    const query = queryBuilder.query([
+      {
+        operation: "getPublicationNames",
+        fields: [
+          {
+            operation: "publication",
+            variables: { id: 12 },
+            fields: ["id", "name"],
+          },
+        ],
+      },
+    ]);
+
+    expect(query).toEqual({
+      query: `query ($id: Int) { getPublicationNames  { publication (id: $id) { id, name } } }`,
+      variables: { id: 12 },
+    });
+  });
 });
 
 describe("Mutation", () => {
@@ -294,6 +314,7 @@ describe("Mutation", () => {
     });
   });
 });
+
 describe("Subscriptions", () => {
   test("generates subscriptions", () => {
     const query = queryBuilder.subscription([

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -151,7 +151,7 @@ describe("Query", () => {
         fields: [
           {
             operation: "publication",
-            variables: { id: 12 },
+            variables: { id: { value: 12, type: "ID" } },
             fields: ["id", "name"],
           },
         ],
@@ -159,8 +159,8 @@ describe("Query", () => {
     ]);
 
     expect(query).toEqual({
-      query: `query ($id: Int) { getPublicationNames  { publication (id: $id) { id, name } } }`,
-      variables: { id: 12 },
+      query: `query ($id: ID) { getPublicationNames  { publication (id: $id) { id, name } } }`,
+      variables: { id: { type: "ID", value: 12 } },
     });
   });
 });


### PR DESCRIPTION
fix #3

Hi, I have used this lib for a moment, and really like what it brings, and I fell upon a missing feature (that was brought up in your [issue #3](https://github.com/atulmy/gql-query-builder/issues/3)), adding variables to fields, like so :

```js
query ($id: ID) { 
  getPublicationNames  { 
    publication (id: $id) {
      id, 
      name
    } 
  } 
}
```

I added a test case, and worked on the syntax that was provided on the issue :

```js
const query = gql.query({
  operation: 'users',
  variables: { limit: 4 },
  fields: [
    'name',
    'email'
    {
      operation: 'posts',
      variables: { limit: 10 },
      fields: [
        'title', 
        'body'
      ]
    },
  ]
})
```

It seems to work for me, the tests are ok, and it worked in a real app as a test. If this can be of interest, I'd love to have this added to the library. 

I did try to clean up as much my additions, but feel free to tell me where I could ease the integration, and where could be some improvements or errors.

Thanks a lot !!!