### PR TITLE
Fix: Removal of brackets for scalar operations

### DIFF
--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -35,9 +35,12 @@ export default class Utils {
             if (isNestedField(field)) {
               return Utils.queryNestedFieldMap(field);
             } else if (typeof field === "object") {
-              return `${Object.keys(field)[0]} { ${this.queryFieldsMap(
-                Object.values(field)[0] as Fields
-              )} }`;
+              const values = Object.values(field)[0];
+              return `${Object.keys(field)[0]} ${
+                values.length > 0
+                  ? "{ " + this.queryFieldsMap(values as Fields) + " }"
+                  : ""
+              }`;
             } else {
               return `${field}`;
             }
@@ -49,7 +52,11 @@ export default class Utils {
   public static queryNestedFieldMap(field: NestedField) {
     return `${field.operation} ${this.queryDataNameAndArgumentMap(
       field.variables
-    )} { ${this.queryFieldsMap(field.fields)} }`;
+    )} ${
+      field.fields.length > 0
+        ? "{ " + this.queryFieldsMap(field.fields) + " }"
+        : ""
+    }`;
   }
 
   // Variables map. eg: { "id": 1, "name": "Jon Doe" }

--- a/src/adapters/DefaultQueryAdapter.ts
+++ b/src/adapters/DefaultQueryAdapter.ts
@@ -79,6 +79,10 @@ export default class DefaultQueryAdapter implements IQueryAdapter {
   private operationTemplate() {
     return `${this.operation} ${Utils.queryDataNameAndArgumentMap(
       this.variables
-    )} { ${Utils.queryFieldsMap(this.fields)} }`;
+    )} ${
+      this.fields && this.fields.length > 0
+        ? `{ ${Utils.queryFieldsMap(this.fields)} }`
+        : ""
+    }`;
   }
 }

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -192,6 +192,153 @@ describe("Query", () => {
       },
     });
   });
+
+  test("generates query without extraneous brackets for operation with no fields", () => {
+    const query = queryBuilder.query({
+      operation: "getFilteredUsersCount",
+    });
+
+    expect(query).toEqual({
+      query: `query  { getFilteredUsersCount   }`,
+      variables: {},
+    });
+  });
+
+  test("generates queries without extraneous brackets for operations with no fields", () => {
+    const query = queryBuilder.query([
+      {
+        operation: "getFilteredUsersCount",
+      },
+      {
+        operation: "getAllUsersCount",
+      },
+    ]);
+
+    expect(query).toEqual({
+      query: `query  { getFilteredUsersCount   getAllUsersCount   }`,
+      variables: {},
+    });
+  });
+
+  test("generates query without extraneous brackets for operations with empty fields", () => {
+    const query = queryBuilder.query({
+      operation: "getFilteredUsersCount",
+      fields: [],
+    });
+
+    expect(query).toEqual({
+      query: `query  { getFilteredUsersCount   }`,
+      variables: {},
+    });
+  });
+
+  test("generates queries without extraneous brackets for operations with empty fields", () => {
+    const query = queryBuilder.query([
+      {
+        operation: "getFilteredUsersCount",
+        fields: [],
+      },
+      {
+        operation: "getAllUsersCount",
+        fields: [],
+      },
+    ]);
+
+    expect(query).toEqual({
+      query: `query  { getFilteredUsersCount   getAllUsersCount   }`,
+      variables: {},
+    });
+  });
+
+  test("generates query without extraneous brackets for operation with empty fields of fields", () => {
+    const query = queryBuilder.query({
+      operation: "getFilteredUsers",
+      fields: [
+        {
+          count: [],
+        },
+      ],
+    });
+
+    expect(query).toEqual({
+      query: `query  { getFilteredUsers  { count  } }`,
+      variables: {},
+    });
+  });
+
+  test("generates queries without extraneous brackets for operations with empty fields of fields", () => {
+    const query = queryBuilder.query([
+      {
+        operation: "getFilteredUsers",
+        fields: [
+          {
+            count: [],
+          },
+        ],
+      },
+      {
+        operation: "getFilteredPosts",
+        fields: [
+          {
+            count: [],
+          },
+        ],
+      },
+    ]);
+
+    expect(query).toEqual({
+      query: `query  { getFilteredUsers  { count  } getFilteredPosts  { count  } }`,
+      variables: {},
+    });
+  });
+
+  test("generates query without extraneous brackets for operation with nested operation empty fields", () => {
+    const query = queryBuilder.query({
+      operation: "getFilteredUsers",
+      fields: [
+        {
+          operation: "average_age",
+          fields: [],
+          variables: { format: "months" },
+        },
+      ],
+    });
+
+    expect(query).toEqual({
+      query: `query ($format: String) { getFilteredUsers  { average_age (format: $format)  } }`,
+      variables: { format: "months" },
+    });
+  });
+
+  test("generates queries without extraneous brackets for operations with nested operation empty fields", () => {
+    const query = queryBuilder.query([
+      {
+        operation: "getFilteredUsers",
+        fields: [
+          {
+            operation: "average_age",
+            fields: [],
+            variables: {},
+          },
+        ],
+      },
+      {
+        operation: "getFilteredPosts",
+        fields: [
+          {
+            operation: "average_viewers",
+            fields: [],
+            variables: {},
+          },
+        ],
+      },
+    ]);
+
+    expect(query).toEqual({
+      query: `query  { getFilteredUsers  { average_age   } getFilteredPosts  { average_viewers   } }`,
+      variables: {},
+    });
+  });
 });
 
 describe("Mutation", () => {


### PR DESCRIPTION
# ISSUE
* Previously scalar operations contained `{ }` in the output which resulted in a bad request

## Fix
* if the fields property in the root operation or nested operation is empty ie length === 0 then remove the `{ }`
* For fields that are object, if that objects value ie field is empty also remove the `{ }`

This is a fix for [issue#36](https://github.com/atulmy/gql-query-builder/issues/36)

I've also added additional tests as well. Things got a bit messy with strings due to whitespaces ;)
