### PR TITLE
fix: Multiple queries variables doesn't get set in the root query

### DIFF
--- a/src/adapters/DefaultQueryAdapter.ts
+++ b/src/adapters/DefaultQueryAdapter.ts
@@ -25,7 +25,9 @@ export default class DefaultQueryAdapter implements IQueryAdapter {
   }
   // kicks off building for a single query
   public queryBuilder() {
-    return this.operationWrapperTemplate(this.operationTemplate());
+    return this.operationWrapperTemplate(
+      this.operationTemplate(this.variables)
+    );
   }
   // if we have an array of options, call this
   public queriesBuilder(queries: IQueryBuilderOptions[]) {
@@ -35,8 +37,7 @@ export default class DefaultQueryAdapter implements IQueryAdapter {
         if (query) {
           this.operation = query.operation;
           this.fields = query.fields;
-          this.variables = query.variables;
-          tmpl.push(this.operationTemplate());
+          tmpl.push(this.operationTemplate(query.variables));
         }
       });
       return tmpl.join(" ");
@@ -76,9 +77,9 @@ export default class DefaultQueryAdapter implements IQueryAdapter {
     };
   }
   // query
-  private operationTemplate() {
+  private operationTemplate(variables: IQueryBuilderOptions[]) {
     return `${this.operation} ${Utils.queryDataNameAndArgumentMap(
-      this.variables
+      variables
     )} { ${Utils.queryFieldsMap(this.fields)} }`;
   }
 }

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -192,6 +192,60 @@ describe("Query", () => {
       },
     });
   });
+
+  test("generates queries with object variables for multiple queries", () => {
+    const query = queryBuilder.query([
+      {
+        operation: "getPublicationData",
+        variables: { id: { type: "ID", value: 12 } },
+        fields: ["publishedAt"],
+      },
+      {
+        operation: "getPublicationUsers",
+        variables: { name: { value: "johndoe" } },
+        fields: ["full_name"],
+      },
+    ]);
+
+    expect(query).toEqual({
+      query: `query ($id: ID, $name: String) { getPublicationData (id: $id) { publishedAt } getPublicationUsers (name: $name) { full_name } }`,
+      variables: {
+        id: 12,
+        name: "johndoe",
+      },
+    });
+  });
+
+  test("generates queries with object variables for multiple queries with nested variables", () => {
+    const query = queryBuilder.query([
+      {
+        operation: "getPublicationData",
+        variables: { id: { type: "ID", value: 12 } },
+        fields: [
+          "publishedAt",
+          {
+            operation: "publicationOrg",
+            variables: { location: "mars" },
+            fields: ["name"],
+          },
+        ],
+      },
+      {
+        operation: "getPublicationUsers",
+        variables: { name: { value: "johndoe" } },
+        fields: ["full_name"],
+      },
+    ]);
+
+    expect(query).toEqual({
+      query: `query ($id: ID, $location: String, $name: String) { getPublicationData (id: $id) { publishedAt, publicationOrg (location: $location) { name } } getPublicationUsers (name: $name) { full_name } }`,
+      variables: {
+        id: 12,
+        location: "mars",
+        name: "johndoe",
+      },
+    });
+  });
 });
 
 describe("Mutation", () => {


### PR DESCRIPTION
This is a fix for my [issue#38](https://github.com/atulmy/gql-query-builder/issues/38)