### PR TITLE
Add support for invoking mutations nested under other fields

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -602,6 +602,93 @@ describe("Mutation", () => {
       variables: {},
     });
   });
+
+  test("generates nested mutation operations without variables", () => {
+    const query = queryBuilder.mutation({
+      operation: "namespaceField",
+      fields: [
+        {
+          operation: "innerMutation",
+          fields: ["id"],
+          variables: {},
+        },
+      ],
+    });
+
+    expect(query).toEqual({
+      query: `mutation  {
+  namespaceField  {
+    innerMutation  { id }
+  }
+}`,
+      variables: {},
+    });
+  });
+
+  test("generates nested mutation operations with variables", () => {
+    const query = queryBuilder.mutation({
+      operation: "namespaceField",
+      fields: [
+        {
+          operation: "innerMutation",
+          variables: {
+            name: { value: "stringy" },
+          },
+          fields: ["id"],
+        },
+      ],
+    });
+
+    expect(query).toEqual({
+      query: `mutation ($name: String) {
+  namespaceField  {
+    innerMutation (name: $name) { id }
+  }
+}`,
+      variables: { name: "stringy" },
+    });
+  });
+
+  test("generates multiple nested mutation operations with variables", () => {
+    const query = queryBuilder.mutation([
+      {
+        operation: "namespaceField",
+        fields: [
+          {
+            operation: "mutationA",
+            variables: {
+              nameA: { value: "A" },
+            },
+            fields: ["id"],
+          },
+        ],
+      },
+      {
+        operation: "namespaceField",
+        fields: [
+          {
+            operation: "mutationB",
+            variables: {
+              nameB: { value: "B" },
+            },
+            fields: ["id"],
+          },
+        ],
+      },
+    ]);
+
+    expect(query).toEqual({
+      query: `mutation ($nameB: String, $nameA: String) {
+  namespaceField  {
+    mutationA (nameA: $nameA) { id }
+  }
+  namespaceField  {
+    mutationB (nameB: $nameB) { id }
+  }
+}`,
+      variables: { nameA: "A", nameB: "B" },
+    });
+  });
 });
 
 describe("Subscriptions", () => {


### PR DESCRIPTION
Just like GraphQL queries can have operations at any level, so can mutations! This adds support that the `DefaultQueryAdapter` already has to the `DefaultMutationAdapter` for executing mutations nested under other fields. See the tests for some examples.

One more thing I could maybe do is factor out some of the shared code between the adapters into `Utils`, but I wasn't really sure what is supposed to be shared vs not. Happy to change it up if you'd like @atulmy !