### PR TITLE
Refactor to fix list type definition of VariableOptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,13 +79,13 @@ const subscription = gql.subscription(options: object, adapter?: MyCustomSubscri
     <td>
       { key: value } eg: <code>{ id: 1 }</code>
       <br/><br/>
-      { key: { value: value, required: true, type: GQL type, list: true,name: argument name } eg:
+      { key: { value: value, required: true, type: GQL type, list: true, name: argument name } eg:
       <br />
       <code>
       {
         email: { value: "user@example.com", required: true },
         password: { value: "123456", required: true },
-        secondaryEmails: { value: [], required: false, type: 'String', list: true,name: secondaryEmail }
+        secondaryEmails: { value: [], required: false, type: 'String', list: true, name: secondaryEmail }
       }
       </code>
     </td>

--- a/src/VariableOptions.ts
+++ b/src/VariableOptions.ts
@@ -3,7 +3,7 @@ type VariableOptions =
       type?: string;
       name?: string;
       value: any;
-      list?: boolean;
+      list?: boolean | [boolean];
       required?: boolean;
     }
   | { [k: string]: any };


### PR DESCRIPTION
According to implementation and  #28, the `list` type definition of VariableOptions is wrong.

* src/Utils.ts

```typescript
      } else if (Array.isArray(variable.list)) {
        type = `[${type}${variable.list[0] ? "!" : ""}]`;
      }
```