### PR TITLE
Use variable `name` when generating mutations

### DIFF
--- a/src/adapters/DefaultMutationAdapter.ts
+++ b/src/adapters/DefaultMutationAdapter.ts
@@ -45,16 +45,6 @@ export default class DefaultMutationAdapter implements IMutationAdapter {
       content.join("\n  ")
     );
   }
-  // Convert object to name and argument map. eg: (id: $id)
-  private queryDataNameAndArgumentMap() {
-    return this.variables && Object.keys(this.variables).length
-      ? `(${Object.keys(this.variables).reduce(
-          (dataString, key, i) =>
-            `${dataString}${i !== 0 ? ", " : ""}${key}: $${key}`,
-          ""
-        )})`
-      : "";
-  }
 
   private queryDataArgumentAndTypeMap(variablesUsed: any): string {
     if (this.fields && typeof this.fields === "object") {
@@ -89,7 +79,7 @@ export default class DefaultMutationAdapter implements IMutationAdapter {
   }
 
   private operationTemplate(operation: string) {
-    return `${operation} ${this.queryDataNameAndArgumentMap()} ${
+    return `${operation} ${Utils.queryDataNameAndArgumentMap(this.variables)} ${
       this.fields && this.fields.length > 0
         ? `{
     ${Utils.queryFieldsMap(this.fields)}

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -636,6 +636,48 @@ describe("Mutation", () => {
     });
   });
 
+  test("generates multiple mutations with named variables", () => {
+    const query = queryBuilder.mutation([
+      {
+        operation: "delete0: deleteUser",
+        variables: {
+          id0: {
+            name: "id",
+            type: "ID",
+            value: "user_1234",
+          },
+        },
+        fields: ["id"],
+      },
+      {
+        operation: "delete1: deleteUser",
+        variables: {
+          id1: {
+            name: "id",
+            type: "ID",
+            value: "user_5678",
+          },
+        },
+        fields: ["id"],
+      },
+    ]);
+
+    expect(query).toEqual({
+      query: `mutation ($id0: ID, $id1: ID) {
+  delete0: deleteUser (id: $id0) {
+    id
+  }
+  delete1: deleteUser (id: $id1) {
+    id
+  }
+}`,
+      variables: {
+        id0: "user_1234",
+        id1: "user_5678",
+      },
+    });
+  });
+
   test("generates mutation with required variables", () => {
     const query = queryBuilder.mutation({
       operation: "userSignup",


### PR DESCRIPTION
This resolves #62 whereby the `name` option on variables is ignored when generating mutations.

This is useful when generating a batch of the same mutations, which each requiring different variable values.