### PR TITLE
feat(fields): add support to multiple nested fields

### DIFF
--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -35,12 +35,24 @@ export default class Utils {
             if (isNestedField(field)) {
               return Utils.queryNestedFieldMap(field);
             } else if (typeof field === "object") {
-              const values = Object.values(field)[0];
-              return `${Object.keys(field)[0]} ${
-                values.length > 0
-                  ? "{ " + this.queryFieldsMap(values as Fields) + " }"
-                  : ""
-              }`;
+              let result = "";
+
+              Object.entries<Fields>(field as Record<string, Fields>).forEach(
+                ([key, values], index, array) => {
+                  result += `${key} ${
+                    values.length > 0
+                      ? "{ " + this.queryFieldsMap(values) + " }"
+                      : ""
+                  }`;
+
+                  // If it's not the last item in array, join with comma
+                  if (index < array.length - 1) {
+                    result += ", ";
+                  }
+                }
+              );
+
+              return result;
             } else {
               return `${field}`;
             }

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -69,13 +69,42 @@ describe("Query", () => {
             {
               address: ["city", "country"],
             },
+            {
+              account: ["holder"],
+            },
           ],
         },
       ],
     });
 
     expect(query).toEqual({
-      query: `query  { orders  { id, amount, user { id, name, email, address { city, country } } } }`,
+      query: `query  { orders  { id, amount, user { id, name, email, address { city, country }, account { holder } } } }`,
+      variables: {},
+    });
+  });
+
+  test("generates query with multiple sub fields selection in same object", () => {
+    const query = queryBuilder.query({
+      operation: "orders",
+      fields: [
+        "id",
+        "amount",
+        {
+          user: [
+            "id",
+            "name",
+            "email",
+            {
+              address: ["city", "country"],
+              account: ["holder"],
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(query).toEqual({
+      query: `query  { orders  { id, amount, user { id, name, email, address { city, country }, account { holder } } } }`,
       variables: {},
     });
   });


### PR DESCRIPTION
Hi! First of all, thank you for your amazing package :)

When building the queries, I noticed that it was not possible to pass multiple nested fields in the same object. 
I think that for simple queries, using the same object is cleaner than using one object per relationship.

Note that as far as I know these changes will not affect current behaviour, so no breaking changes.

### Currently:
```js
const query = gql({
  operation: 'posts',
  fields: [
    'id',
    'title',
    'text',
    {
      author: [
        'id',
        'name',
        'email'
      ]
    },
    // Second relation must be in another object
    {
      comments: [
        'id',
        'name',
        'body'
      ]
    }
  ]
})
```

### Add support to:
```js
const query = gql({
  operation: 'posts',
  fields: [
    'id',
    'title',
    'text',
    {
      author: [
        'id',
        'name',
        'email'
      ],
      // Second relation in the same object
      comments: [
        'id',
        'name',
        'body'
      ]
    },
  ]
})
```
### Both will output the same query:
```
query {
  posts  {
    id,
    title,
    text,
    author {
      id,
      name,
      email
    },
    comments {
      id,
      name,
      body
    }
  }
}
```