### PR TITLE
Added inlineSources: true to tsconfig.json

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
     "target": "es5",
     "strict": true,
     "sourceMap": true,
+    "inlineSources": true,
     "outDir": "build",
     "typeRoots": ["node_modules/@types"],
     "forceConsistentCasingInFileNames": true,


### PR DESCRIPTION
Hey there 👋

**TLDR**

I'm hoping to turn on [`inlineSources`](https://www.typescriptlang.org/tsconfig#inlineSources) in your tsconfig.json file so that webpack stops complaining.

**Explanation**

I'm working on the [gadget-inc/js-clients](https://github.com/gadget-inc/js-clients) packages and I'm trying to get rid of webpack source map warnings from being emitted when someone uses our react client in a create-react-app v5 project.

I was able to fix the warnings with [this (soon to be merged) PR](https://github.com/gadget-inc/js-clients/pull/26), but our clients use your package under the hood, and it looks like your package also emits warnings.

```shell
Failed to parse source map from 'node_modules/gql-query-builder/src/NestedField.ts' file:
Error: ENOENT: no such file or directory, open 'node_modules/gql-query-builder/src/NestedField.ts'
```

I figured out that webpack is complaining because your source maps are referencing files in your `src` directory but you don't include your `src` directory when you publish to npm.

To fix this, you could do one of the following:

1. include your `src` directory when publishing to npm
2. turn on `inlineSources` in your tsconfig.json

I think the `inlineSources` option is the easiest one... but it's up to you 😄 