### PR TITLE
Support operation name for mutations

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,9 +159,10 @@ const subscription = gql.subscription(options: object, adapter?: MyCustomSubscri
 11. <a href="#mutation-with-required-variables">Mutation (with required variables)</a>
 12. <a href="#mutation-with-custom-types">Mutation (with custom types)</a>
 13. <a href="#mutation-with-adapter-defined">Mutation (with adapter defined)</a>
-14. <a href="#subscription">Subscription</a>
-15. <a href="#subscription-with-adapter-defined">Subscription (with adapter defined)</a>
-16. <a href="#example-with-axios">Example with Axios</a>
+14. <a href="#mutation-with-operation-name">Mutation (with operation name)</a>
+15. <a href="#subscription">Subscription</a>
+16. <a href="#subscription-with-adapter-defined">Subscription (with adapter defined)</a>
+17. <a href="#example-with-axios">Example with Axios</a>
 
 #### Query:
 
@@ -619,6 +620,32 @@ mutation SomethingIDidInMyAdapter {
 [↑ all examples](#examples)
 
 Take a peek at [DefaultMutationAdapter](src/adapters/DefaultMutationAdapter.ts) to get an understanding of how to make a new adapter.
+
+#### Mutation (with operation name):
+
+```javascript
+import * as gql from 'gql-query-builder'
+
+const query = gql.mutation({
+  operation: 'thoughts',
+  fields: ['id', 'name', 'thought']
+}, undefined, {
+  operationName: 'someoperation'
+})
+
+console.log(query)
+
+// Output
+mutation someoperation {
+  thoughts {
+    id
+    name
+    thought
+  }
+}
+```
+
+[↑ all examples](#examples)
 
 #### Subscription:
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1032,6 +1032,37 @@ describe("Mutation", () => {
       variables: { nameA: "A", nameB: "B" },
     });
   });
+
+  test.only("generates mutation with operation name", () => {
+    const query = queryBuilder.mutation(
+      [
+        {
+          operation: "thoughtCreate",
+          variables: {
+            name: "Tyrion Lannister",
+            thought: "I drink and I know things.",
+          },
+          fields: ["id"],
+        },
+      ],
+      undefined,
+      {
+        operationName: "operation",
+      }
+    );
+
+    expect(query).toEqual({
+      query: `mutation operation ($name: String, $thought: String) {
+      thoughtCreate (name: $name, thought: $thought) {
+    id
+  }
+    }`,
+      variables: {
+        name: "Tyrion Lannister",
+        thought: "I drink and I know things.",
+      },
+    });
+  });
 });
 
 describe("Subscriptions", () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,25 +31,26 @@ function queryOperation(
 
 function mutationOperation(
   options: IQueryBuilderOptions | IQueryBuilderOptions[],
-  adapter?: IMutationAdapter
+  adapter?: IMutationAdapter,
+  config?: any
 ) {
   let customAdapter: IMutationAdapter;
   let defaultAdapter: IMutationAdapter;
   if (Array.isArray(options)) {
     if (adapter) {
       // @ts-ignore
-      customAdapter = new adapter(options);
+      customAdapter = new adapter(options, config);
       return customAdapter.mutationsBuilder(options);
     }
-    defaultAdapter = new DefaultMutationAdapter(options);
+    defaultAdapter = new DefaultMutationAdapter(options, config);
     return defaultAdapter.mutationsBuilder(options);
   }
   if (adapter) {
     // @ts-ignore
-    customAdapter = new adapter(options);
+    customAdapter = new adapter(options, config);
     return customAdapter.mutationBuilder();
   }
-  defaultAdapter = new DefaultMutationAdapter(options);
+  defaultAdapter = new DefaultMutationAdapter(options, config);
   return defaultAdapter.mutationBuilder();
 }
 


### PR DESCRIPTION
This PR addresses issue #72 in order to allow passing an operationName to mutations (in the same way that is already possible for queries). I've also added a test for it in index.test.ts and updated the readme with example usage.