### PR TITLE
Added the exporting of the types

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -83,4 +83,7 @@ export {
   mutationOperation as mutation,
   queryOperation as query,
   adapters,
+  IQueryAdapter,
+  ISubscriptionAdapter,
+  IQueryBuilderOptions,
 };


### PR DESCRIPTION
I added the exporting of types so you can do this and get intellisense in IDEs:

```ts
import { IQueryBuilderOptions, query } from 'gql-query-builder'
let options: IQueryBuilderOptions = {
      operation: 'xxxxx',
      variables: {
       ...
      },
      fields: []
}
```

This just adds more accessibility to the package, and doesn't affect anything other than just exporting the types