### PR TITLE
Make it possible to request a subscription with empty fields

### DIFF
--- a/src/adapters/DefaultSubscriptionAdapter.ts
+++ b/src/adapters/DefaultSubscriptionAdapter.ts
@@ -89,10 +89,9 @@ export default class DefaultSubscriptionAdapter
       typeof this.operation === "string"
         ? this.operation
         : `${this.operation.alias}: ${this.operation.name}`;
-
-    return `${operationName} ${this.queryDataNameAndArgumentMap()} {
-    ${this.queryFieldsMap(this.fields)}
-  }`;
+    const requestFields = this.queryFieldsMap(this.fields);
+    return `${operationName} ${this.queryDataNameAndArgumentMap()} ${requestFields ? 
+    '{ ${requestFields} }' : ''}`;
   }
 
   // Fields selection map. eg: { id, name }


### PR DESCRIPTION
This changes will made it possible to request a subscription with return type string and without fields.

Before:
```
subscription {
   events {
  }
}
```

After:
```
subscription {
   events
}
```